### PR TITLE
fix: item consumption caused by incorrect float comparison

### DIFF
--- a/src/main/java/dev/shadowsoffire/apothic_spawners/stats/PercentageStat.java
+++ b/src/main/java/dev/shadowsoffire/apothic_spawners/stats/PercentageStat.java
@@ -28,7 +28,7 @@ public class PercentageStat extends CustomStat<Float> {
     public boolean applyModifier(ApothSpawnerTile spawner, Float value, Optional<Float> min, Optional<Float> max) {
         Float old = this.getValue(spawner);
         this.setValue(spawner, this.clamp(old + value, min, max));
-        return old != this.getValue(spawner);
+        return !old.equals(this.getValue(spawner));
     }
 
     @Override

--- a/src/main/java/dev/shadowsoffire/apothic_spawners/stats/PercentageStat.java
+++ b/src/main/java/dev/shadowsoffire/apothic_spawners/stats/PercentageStat.java
@@ -28,7 +28,7 @@ public class PercentageStat extends CustomStat<Float> {
     public boolean applyModifier(ApothSpawnerTile spawner, Float value, Optional<Float> min, Optional<Float> max) {
         Float old = this.getValue(spawner);
         this.setValue(spawner, this.clamp(old + value, min, max));
-        return !old.equals(this.getValue(spawner));
+        return Math.abs(old - this.getValue(spawner)) > 1e-6f;
     }
 
     @Override


### PR DESCRIPTION
Because the java Float Object is being used != compares the Object reference and not the value making it always return true so even if min/max is reached it eats the item